### PR TITLE
번역 페이지 개발

### DIFF
--- a/data/services/services.hooks.ts
+++ b/data/services/services.hooks.ts
@@ -3,6 +3,8 @@ import {
   UseInfiniteQueryOptions,
   useMutation,
   UseMutationOptions,
+  useQuery,
+  UseQueryOptions,
 } from 'react-query';
 import { AxiosError } from 'axios';
 import { SuccessResponse } from '~/shared/types';
@@ -11,10 +13,12 @@ import {
   Writer,
   ContentsSearchParams,
   MainContentsResponse,
+  TranslatingContentsData,
 } from './services.model';
 import {
   getMainContents,
   getMainWriters,
+  getTranslatingContents,
   postWritingContents,
 } from './services.api';
 
@@ -65,6 +69,26 @@ export function useInfinityWriters(
       retry: 2,
       ...options,
       refetchOnWindowFocus: false,
+    },
+  );
+}
+
+export function useTranslatingContents(
+  contentsId: number,
+  options:
+    | UseQueryOptions<
+        SuccessResponse<TranslatingContentsData>,
+        AxiosError<unknown>,
+        SuccessResponse<TranslatingContentsData>
+      >
+    | undefined = {},
+) {
+  return useQuery<SuccessResponse<TranslatingContentsData>, AxiosError>(
+    ['/services/translating_contents', contentsId],
+    () => getTranslatingContents(contentsId),
+    {
+      retry: 2,
+      ...options,
     },
   );
 }

--- a/pages/translating.tsx
+++ b/pages/translating.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { NextSeo } from 'next-seo';
-import { Box, Button } from '@nolmungshemung/ui-kits';
+import { Box, Button, styled } from '@nolmungshemung/ui-kits';
 import { BasicInput } from '~/components/Input';
 import * as Table from '~/components/Table';
 import { GetServerSidePropsContext, NextPage, PreviewData } from 'next';
@@ -17,6 +17,10 @@ import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
+
+const StyledTextEditor = styled(TextEditor, {
+  width: '98%',
+});
 
 const Translating: NextPage = function () {
   const router = useRouter();
@@ -86,18 +90,26 @@ const Translating: NextPage = function () {
           justifyContent: 'center',
           alignItems: 'center',
           marginTop: '$sp-32',
+          height: 'calc(100% - $height-appbar - $space$sp-32 + 0.5rem)',
         }}
       >
         <Box
           css={{
-            display: 'flex',
-            flexDirection: 'row',
+            display: 'grid',
+            gridTemplateColumns: '1fr 50px 1fr',
             justifyContent: 'center',
             alignItems: 'center',
-            width: '90%',
+            width: '100%',
+            height: '100%',
           }}
         >
-          <Table.Wrapper css={{ width: '45%', height: '700px', margin: '0' }}>
+          <Table.Wrapper
+            css={{
+              width: 'calc(100% - $sp-50)',
+              height: '100%',
+              margin: '0 0 0 $sp-50',
+            }}
+          >
             <tbody>
               <Table.TableRow>
                 <Table.TitleTd colSpan={2}>원문</Table.TitleTd>
@@ -138,13 +150,13 @@ const Translating: NextPage = function () {
                   </span>
                 </Table.ContentsTd>
               </Table.TableRow>
-              <Table.TableRow css={{ height: '600px' }}>
+              <Table.TableRow css={{ height: '100%' }}>
                 <Table.TitleTd>{'내용'}</Table.TitleTd>
-                <Table.ContentsTd>
+                <Table.ContentsTd css={{ width: 'calc(100% - 20px)' }}>
                   <Box
                     css={{
-                      width: '$width-xs',
-                      height: '600px',
+                      width: '100%',
+                      height: '100%',
                       border: 'none',
                       lineHeight: '$base',
                       whiteSpace: 'pre-wrap',
@@ -154,7 +166,7 @@ const Translating: NextPage = function () {
                   >
                     {isLoading
                       ? [...Array(20)].map((index) => (
-                          <Skeleton key={index + Math.random()} width={300} />
+                          <Skeleton key={index + Math.random()} width="80%" />
                         ))
                       : targetOriginalContents?.data.contents ?? ''}
                   </Box>
@@ -164,16 +176,23 @@ const Translating: NextPage = function () {
           </Table.Wrapper>
           <Box
             css={{
-              textAlign: 'center',
-              width: '10%',
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexDirection: 'column',
+              backgroundColor: 'white',
             }}
           >
-            <Box>
-              <RiRefreshLine />
-            </Box>
-            <Box>번역</Box>
+            <RiRefreshLine size="24" color="#DBAA49" />
+            <Box css={{ color: '$primary' }}>번역</Box>
           </Box>
-          <Table.Wrapper css={{ width: '45%', height: '700px', margin: '0' }}>
+          <Table.Wrapper
+            css={{
+              height: '100%',
+              margin: '0 $sp-50 0 0',
+            }}
+          >
             <tbody>
               <Table.TableRow>
                 <Table.TitleTd colSpan={2}>번역</Table.TitleTd>
@@ -209,10 +228,10 @@ const Translating: NextPage = function () {
                   <BasicInput onChange={onLanguageChange} />
                 </Table.ContentsTd>
               </Table.TableRow>
-              <Table.TableRow css={{ height: '600px' }}>
+              <Table.TableRow css={{ height: '100%' }}>
                 <Table.TitleTd>{'내용'}</Table.TitleTd>
                 <Table.ContentsTd>
-                  <TextEditor
+                  <StyledTextEditor
                     value={writingContents.contents}
                     onChange={onContentsChange}
                   />
@@ -221,7 +240,13 @@ const Translating: NextPage = function () {
             </tbody>
           </Table.Wrapper>
         </Box>
-        <Box css={{ marginTop: '$sp-30' }}>
+        <Box
+          css={{
+            margin: '1rem 0',
+            width: '100%',
+            textAlign: 'center',
+          }}
+        >
           <Button
             size="lg"
             css={{

--- a/pages/translating.tsx
+++ b/pages/translating.tsx
@@ -1,0 +1,212 @@
+import React, { useState } from 'react';
+import { NextSeo } from 'next-seo';
+import { Box, Button, Input } from '@nolmungshemung/ui-kits';
+import { BasicInput } from '~/components/Input';
+import * as Table from '~/components/Table';
+import { NextPage } from 'next';
+import { WritingContentsRequest } from '~/data/services/services.model';
+import TextEditor from '~/components/TextEditor/TextEditor';
+import { usePostContents } from '~/data/services/services.hooks';
+import { RiRefreshLine } from 'react-icons/ri';
+
+const initialWriting: WritingContentsRequest = {
+  title: '',
+  thumbnail: '',
+  introduction: '',
+  contents: '',
+  writerId: '',
+  language: '',
+  isTranslate: false,
+  originalId: 0,
+};
+
+const Translating: NextPage = function () {
+  const [writingContents, setWritingContents] =
+    useState<WritingContentsRequest>(initialWriting);
+
+  const {
+    data: response,
+    isLoading,
+    mutate,
+  } = usePostContents({
+    onSuccess() {
+      window.alert(response?.msg ?? '저장되었습니다!');
+    },
+    onError(error) {
+      console.error(error);
+    },
+  });
+
+  const onTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setWritingContents({ ...writingContents, title: value });
+  };
+
+  const onContentsChange = (value: string) => {
+    setWritingContents({ ...writingContents, contents: value });
+  };
+
+  const onDescChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setWritingContents({ ...writingContents, introduction: value });
+  };
+
+  const onThumbnailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setWritingContents({ ...writingContents, thumbnail: value });
+  };
+
+  const onSubmit = () => {
+    mutate(writingContents);
+  };
+
+  return (
+    <>
+      <NextSeo
+        title="WritingHub: 번역하기"
+        description="라이팅허브 번역하기 화면"
+      />
+      <Box
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          marginTop: '$sp-32',
+        }}
+      >
+        <Box
+          css={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+            width: '90%',
+          }}
+        >
+          <Table.Wrapper css={{ width: '45%', height: '700px', margin: '0' }}>
+            <tbody>
+              <Table.TableRow>
+                <Table.TitleTd colspan="2">원문</Table.TitleTd>
+              </Table.TableRow>
+              <Table.TableRow>
+                <Table.TitleTd>{'제목'}</Table.TitleTd>
+                <Table.ContentsTd>
+                  <BasicInput readOnly />
+                </Table.ContentsTd>
+              </Table.TableRow>
+              <Table.TableRow>
+                <Table.TitleTd>{'글 소개'}</Table.TitleTd>
+                <Table.ContentsTd>
+                  <BasicInput readOnly />
+                </Table.ContentsTd>
+              </Table.TableRow>
+              <Table.TableRow>
+                <Table.TitleTd>{'썸네일'}</Table.TitleTd>
+                <Table.ContentsTd>
+                  <BasicInput readOnly />
+                </Table.ContentsTd>
+              </Table.TableRow>
+              <Table.TableRow css={{ height: '600px' }}>
+                <Table.TitleTd>{'내용'}</Table.TitleTd>
+                <Table.ContentsTd>
+                  <Input.Text
+                    css={{
+                      width: '95%',
+                      height: '99%',
+                      border: 'none',
+                      '&:focus': {
+                        outline: 'none',
+                      },
+                      backgroundColor: '$gray',
+                    }}
+                    readOnly
+                  />
+                </Table.ContentsTd>
+              </Table.TableRow>
+            </tbody>
+          </Table.Wrapper>
+          <Box
+            css={{
+              textAlign: 'center',
+              width: '10%',
+            }}
+          >
+            <Box>
+              <RiRefreshLine />
+            </Box>
+            <Box>번역</Box>
+          </Box>
+          <Table.Wrapper css={{ width: '45%', height: '700px', margin: '0' }}>
+            <tbody>
+              <Table.TableRow>
+                <Table.TitleTd colspan="2">번역</Table.TitleTd>
+              </Table.TableRow>
+              <Table.TableRow>
+                <Table.TitleTd>{'제목'}</Table.TitleTd>
+                <Table.ContentsTd>
+                  <BasicInput
+                    onChange={onTitleChange}
+                    placeholder={'제목을 입력해주세요.'}
+                  />
+                </Table.ContentsTd>
+              </Table.TableRow>
+              <Table.TableRow>
+                <Table.TitleTd>{'글 소개'}</Table.TitleTd>
+                <Table.ContentsTd>
+                  <BasicInput
+                    onChange={onDescChange}
+                    placeholder={'"이 글은 어떤 글인가요?" 최대 30자'}
+                    maxLength={30}
+                  />
+                </Table.ContentsTd>
+              </Table.TableRow>
+              <Table.TableRow>
+                <Table.TitleTd>{'썸네일'}</Table.TitleTd>
+                <Table.ContentsTd>
+                  <BasicInput onChange={onThumbnailChange} />
+                </Table.ContentsTd>
+              </Table.TableRow>
+              <Table.TableRow css={{ height: '600px' }}>
+                <Table.TitleTd>{'내용'}</Table.TitleTd>
+                <Table.ContentsTd>
+                  <TextEditor
+                    value={writingContents.contents}
+                    onChange={onContentsChange}
+                  />
+                </Table.ContentsTd>
+              </Table.TableRow>
+            </tbody>
+          </Table.Wrapper>
+          {isLoading && <div>Loading...</div>}
+        </Box>
+        <Box css={{ marginTop: '$sp-30' }}>
+          <Button
+            size="lg"
+            css={{
+              width: '5rem',
+              border: '1px solid #C4C7CA',
+              margin: '0 $sp-06',
+              cursor: 'pointer',
+            }}
+          >
+            {'취소'}
+          </Button>
+          <Button
+            size="lg"
+            color="primary"
+            css={{
+              width: '5rem',
+              cursor: 'pointer',
+            }}
+            onClick={onSubmit}
+          >
+            {'등록완료'}
+          </Button>
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+export default Translating;


### PR DESCRIPTION
### Short description

작품 번역 페이지 개발

### Proposed changes

- translating 페이지 퍼블리싱
- API 연동 완료
- 로딩 Skeleton UI 추가

### Issue
- translating page 진입 경로 확인 필요 => 어디서 무엇을 클릭해서 오는건지, target의 contetnsId는 어떻게 얻는지, 현재는 url query param으로 설정하고 진행함
- translating의 언어 선택 방법을 select로 할지 input으로 할지 결정 필요-> select로 할 경우 ui-kits 추가 없이 그대로 사용할 것인지 결정 필요
- translating의 writerId는 original의 writerId인가 번역자의 writerId인지 확인 필요 -> 번역자의 writerId일 경우 해당 값 획득 경로 확인 필요
- texteditor overflow 속성은 뭘로 할지 결정 필요

### How to test (Optional)

http://localhost:3000/translating?contentsId=10

### Screenshots (Optional)

#### Before this PR

#### After this PR

![image](https://user-images.githubusercontent.com/39260956/153424282-7d67e8b6-89d8-48cc-b82d-cc8994da9bed.png)
![image](https://user-images.githubusercontent.com/39260956/153424451-e764e1c8-bd2d-4cc0-b947-b46262bfacfb.png)

### Reference (Optional)

_Closes #43 
