### PR TITLE
필명등록 페이지 추가

### DIFF
--- a/data/user/user.api.ts
+++ b/data/user/user.api.ts
@@ -1,6 +1,6 @@
 import axios from '~/shared/axios';
 import { SuccessResponse } from '~/shared/types';
-import { UserData, NameRegistrationRequest } from './user.model';
+import { UserData } from './user.model';
 
 export async function getUserInfo(userId: string) {
   const { data } = await axios.get<SuccessResponse<UserData>>(
@@ -14,12 +14,10 @@ export async function getUserInfo(userId: string) {
   return data;
 }
 
-export async function postNameRegistration(
-  nameRegistrationRequest: NameRegistrationRequest,
-) {
+export async function postNameRegistration(userData: UserData) {
   const { data } = await axios.post<SuccessResponse>(
     '/user/name_registration',
-    nameRegistrationRequest,
+    userData,
   );
   return data;
 }

--- a/data/user/user.hooks.ts
+++ b/data/user/user.hooks.ts
@@ -1,8 +1,13 @@
-import { useQuery, UseQueryOptions } from 'react-query';
+import {
+  UseMutationOptions,
+  useQuery,
+  UseQueryOptions,
+  useMutation,
+} from 'react-query';
 import { AxiosError } from 'axios';
 import { SuccessResponse } from '~/shared/types';
 import { UserData } from './user.model';
-import { getUserInfo } from './user.api';
+import { getUserInfo, postNameRegistration } from './user.api';
 
 export function useUserInfo(
   userId: string,
@@ -19,6 +24,19 @@ export function useUserInfo(
     () => getUserInfo(userId),
     {
       retry: 2,
+      ...options,
+    },
+  );
+}
+
+export function useNameRegistration(
+  options: UseMutationOptions<SuccessResponse, AxiosError<unknown>, UserData>,
+) {
+  return useMutation<SuccessResponse, AxiosError, UserData>(
+    '/user/name_registration',
+    postNameRegistration,
+    {
+      retry: false,
       ...options,
     },
   );

--- a/data/user/user.model.ts
+++ b/data/user/user.model.ts
@@ -1,9 +1,4 @@
 export interface UserData {
   userId: string;
-  userName: string;
-}
-
-export interface NameRegistrationRequest {
-  userId: string;
-  name: string;
+  userName?: string;
 }

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,11 +1,13 @@
 import { rest, RestRequest } from 'msw';
 import { WritingContentsRequest } from '~/data/services/services.model';
+import { UserData } from '~/data/user/user.model';
 import { API_URL } from '~/shared/constants/environments';
 import {
   ContentsFactory,
   ErrorResponseFactory,
   WriterFactory,
 } from './factories';
+import { camelizeKeys } from 'humps';
 
 export const handlers = [
   rest.get(`${API_URL}/services/main_contents`, (req, res, ctx) => {
@@ -84,7 +86,37 @@ export const handlers = [
         const errorResponse = ErrorResponseFactory.build();
         return res(ctx.status(422), ctx.json(errorResponse));
       }
-      console.log(writingContents);
+
+      return res(
+        ctx.status(200),
+        ctx.json({
+          msg: '응답 성공',
+          data: {},
+        }),
+      );
+    },
+  ),
+  rest.post(
+    `${API_URL}/user/name_registration`,
+    (req: RestRequest<UserData>, res, ctx) => {
+      const userData = camelizeKeys(req.body) as UserData;
+      console.log(userData);
+
+      if (userData.userId === '') {
+        const errorResponse = ErrorResponseFactory.build();
+        return res(ctx.status(422), ctx.json(errorResponse));
+      }
+
+      if (userData.userName === 'invalid') {
+        return res(
+          ctx.status(404),
+          ctx.json({
+            msg: '이미 존재하는 필명입니다.',
+            data: {},
+          }),
+        );
+      }
+
       return res(
         ctx.status(200),
         ctx.json({

--- a/pages/registration/penname.tsx
+++ b/pages/registration/penname.tsx
@@ -1,0 +1,75 @@
+import { NextPage } from 'next';
+import { NextSeo } from 'next-seo';
+import { Box, Text, Button } from '@nolmungshemung/ui-kits';
+import { BasicInput } from '~/components/Input';
+
+const PenName: NextPage = function () {
+  return (
+    <>
+      <NextSeo
+        title="WritingHub: 필명등록"
+        description="라이팅허브 필명등록(수정) 화면"
+      />
+      <Box
+        css={{
+          height: 'calc(100% - 4rem)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          textAlign: 'center',
+        }}
+      >
+        <Box
+          css={{
+            marginBottom: 'calc($sizes$height-appbar * 2)',
+          }}
+        >
+          <Text css={{ fontSize: '5rem' }}>WritingHub</Text>
+          <Box
+            css={{
+              margin: '$sp-08 0 $sp-24',
+            }}
+          >
+            <Text size="xl" css={{ marginRight: '$sp-12' }}>
+              필명 수정
+            </Text>
+            <Text size="xl" color="gray">
+              작품에 등록될 필명을 등록해주세요
+            </Text>
+          </Box>
+          <Box
+            css={{
+              width: '90%',
+              margin: '0 auto $sp-20',
+            }}
+          >
+            <BasicInput
+              type="text"
+              placeholder="필명"
+              css={{
+                backgroundColor: '#EEE',
+                border: '1px solid #E0E0E0',
+                borderRadius: '5px',
+                height: '$height-md',
+                padding: '$sp-06',
+                lineHeight: '100%',
+              }}
+            />
+          </Box>
+          <Button
+            color="primary"
+            size="lg"
+            css={{
+              cursor: 'pointer',
+            }}
+          >
+            등록하기
+          </Button>
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+export default PenName;

--- a/pages/registration/username.tsx
+++ b/pages/registration/username.tsx
@@ -1,9 +1,41 @@
+import { useState, ChangeEvent } from 'react';
 import { NextPage } from 'next';
 import { NextSeo } from 'next-seo';
 import { Box, Text, Button } from '@nolmungshemung/ui-kits';
 import { BasicInput } from '~/components/Input';
+import { useNameRegistration } from '~/data/user/user.hooks';
 
 const PenName: NextPage = function () {
+  const [userName, setUserName] = useState('');
+  const [showError, setShowError] = useState(false);
+
+  const { mutate } = useNameRegistration({
+    onSuccess() {
+      setShowError(false);
+      window.alert('필명이 등록(수정) 되었습니다!');
+    },
+    onError(error) {
+      const errorCode = error.response?.status;
+      if (errorCode === 404) {
+        setShowError(true);
+      } else if (errorCode === 422) {
+        setShowError(false);
+        window.alert('필명 등록(수정)에 실패했습니다. 관리자에게 문의하세요');
+      }
+    },
+  });
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setUserName(e.target.value);
+  };
+
+  const onPenNameRegist = () => {
+    mutate({
+      userId: '',
+      userName,
+    });
+  };
+
   return (
     <>
       <NextSeo
@@ -46,6 +78,8 @@ const PenName: NextPage = function () {
           >
             <BasicInput
               type="text"
+              value={userName}
+              onChange={handleChange}
               placeholder="필명"
               css={{
                 backgroundColor: '#EEE',
@@ -57,12 +91,28 @@ const PenName: NextPage = function () {
               }}
             />
           </Box>
+          {showError && (
+            <Box
+              css={{
+                marginBottom: '$sp-20',
+              }}
+            >
+              <Text
+                css={{
+                  color: 'rgba(222, 14, 14, 0.9)',
+                }}
+              >
+                이미 사용 중인 필명입니다. 다른 필명을 사용해주세요.
+              </Text>
+            </Box>
+          )}
           <Button
             color="primary"
             size="lg"
             css={{
               cursor: 'pointer',
             }}
+            onClick={onPenNameRegist}
           >
             등록하기
           </Button>


### PR DESCRIPTION
- feat: 필명 등록 페이지 퍼블리싱 필명 등록 페이지의 기본 퍼블리싱 진행
- feat: 필명 등록 API 연동 mock api를 이용한 필명등록 API 기능 개발. error code에 따라 중복필명처리, 시스템 alert 처리 추가 - login 기능 추가 후 userId 처리 추가

### Short description

- 필명 등록 페이지를 추가함

### Proposed changes

- 필명등록 페이지 퍼블리싱
- mock api 기준으로 필명등록 API 개발
- error code에 따른 validation 처리 추가

### How to test (Optional)

_How to test this PR_

### Screenshots (Optional)

#### Before this PR

#### After this PR

### Reference (Optional)
close #53
