### PR TITLE
로그인 세션에 따른 페이지 권한관리 로직 개발

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { AppBar, Text, Button, Box, styled } from '@nolmungshemung/ui-kits';
 import Router from 'next/router';
 import { signIn, signOut, useSession } from 'next-auth/react';
+import { WritingHubSession } from '~/data/user/user.model';
 
 const HeaderButton = styled(Button, {
   width: '5rem',
@@ -10,10 +11,16 @@ const HeaderButton = styled(Button, {
   marginRight: '$sp-12',
 });
 
+type QueryString<T = string | number> = Record<string, T>;
+
 export function Header() {
-  const { data: sessionData } = useSession();
-  const handleRouting = (path: string) => {
-    Router.push(path);
+  const { data: session } = useSession();
+
+  const handleRouting = (pathname: string, query?: QueryString) => {
+    Router.push({
+      pathname,
+      query,
+    });
   };
 
   return (
@@ -37,25 +44,37 @@ export function Header() {
         Writing Hub
       </Text>
       <Box>
-        {sessionData && (
+        {session ? (
           <>
-            <HeaderButton size="lg" color="white" outline="black">
+            <HeaderButton
+              size="lg"
+              color="white"
+              outline="black"
+              onClick={() => handleRouting('/registration/username')}
+            >
               필명등록
             </HeaderButton>
-            <HeaderButton size="lg" color="white" outline="black">
+            <HeaderButton
+              size="lg"
+              color="white"
+              outline="black"
+              onClick={() =>
+                handleRouting('/myfeed', {
+                  writerId: (session as WritingHubSession)?.user?.id ?? '',
+                })
+              }
+            >
               내피드
             </HeaderButton>
+            <HeaderButton
+              size="lg"
+              color="white"
+              outline="black"
+              onClick={signOut}
+            >
+              로그아웃
+            </HeaderButton>
           </>
-        )}
-        {sessionData ? (
-          <HeaderButton
-            size="lg"
-            color="white"
-            outline="black"
-            onClick={signOut}
-          >
-            로그아웃
-          </HeaderButton>
         ) : (
           <HeaderButton
             size="lg"

--- a/data/user/user.model.ts
+++ b/data/user/user.model.ts
@@ -1,4 +1,15 @@
+import { Session } from 'next-auth';
+
 export interface UserData {
   userId: string;
   userName?: string;
 }
+
+export type WritingHubSession = Session & {
+  user: {
+    // userId, writerId 와 동일
+    id: string;
+    // userName(필명)
+    penName?: string;
+  };
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -20,7 +20,14 @@ queryClient.setDefaultOptions({
   },
 });
 
-function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
+function MyApp({
+  Component,
+  pageProps: { session, ...pageProps },
+}: AppProps & {
+  Component: {
+    auth: boolean;
+  };
+}) {
   return (
     <>
       <DefaultSeo />

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,8 +1,11 @@
 /* This contains the dynamic route handler for NextAuth.js which will also contain all of your global NextAuth.js configurations.
 https://next-auth.js.org/getting-started/example#add-api-route
 */
+import { AxiosError } from 'axios';
 import NextAuth from 'next-auth';
 import Kakao from 'next-auth/providers/kakao';
+import { getUserInfo, postUserLogin } from '~/data/user/user.api';
+import { WritingHubSession } from '~/data/user/user.model';
 
 export default NextAuth({
   providers: [
@@ -12,6 +15,38 @@ export default NextAuth({
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,
+  callbacks: {
+    async signIn({ user }) {
+      try {
+        const { data: userInfo } = await getUserInfo(user.id);
+        console.log('Login User: ', userInfo);
+      } catch (e) {
+        const status = (e as AxiosError)?.response?.status;
+
+        if (status === 404) {
+          try {
+            await postUserLogin(user.id);
+          } catch (err) {
+            console.error('user create error:: ', err);
+            return false;
+          }
+        }
+      }
+      return true;
+    },
+    async session({ session, token }) {
+      const customSession = session as WritingHubSession;
+
+      if (token) {
+        customSession.user = {
+          ...session.user,
+          id: token.sub ?? '',
+        };
+      }
+
+      return customSession;
+    },
+  },
   pages: {
     signIn: '/login',
     signOut: '/login',

--- a/pages/contents.tsx
+++ b/pages/contents.tsx
@@ -28,6 +28,13 @@ interface ReadingProps {
 function Reading({ contentsId }: ReadingProps) {
   const { data, isLoading } = useReadingContents(contentsId);
 
+  const onTranslatingButtonClick = () => {
+    Router.push({
+      pathname: '/translating',
+      query: { contentsId },
+    });
+  };
+
   const onCardClick = (translatedContentsId: number) => {
     Router.push({
       pathname: '/contents',
@@ -196,6 +203,7 @@ function Reading({ contentsId }: ReadingProps) {
                   margin: '0 $sp-06',
                   cursor: 'pointer',
                 }}
+                onClick={onTranslatingButtonClick}
               >
                 {'번역하기'}
               </Button>
@@ -255,6 +263,13 @@ export async function getServerSideProps(
 ) {
   try {
     const contentsId = Number(context.query.contentsId);
+
+    if (isNaN(contentsId)) {
+      return {
+        notFound: true,
+      };
+    }
+
     const queryClient = new QueryClient();
     await queryClient.prefetchQuery(
       ['/services/reading_contents', contentsId],

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef } from 'react';
-import { NextPage } from 'next';
 import { dehydrate, QueryClient } from 'react-query';
 import Router from 'next/router';
 import { useSearch, useIntersectionObserver } from '~/hooks';
@@ -16,6 +15,8 @@ import { SkeletonCard } from '~/components/Skeleton';
 import { DEFAULT_SEARCH_RANGE } from '~/shared/constants/pagination';
 import { NextSeo } from 'next-seo';
 import { MILLISEC_TO_SECOND } from '~/shared/constants/unit';
+import { getSession } from 'next-auth/react';
+import { GetServerSidePropsContext } from 'next/types';
 
 const StyledMain = styled('div', {
   gridArea: 'main',
@@ -48,7 +49,7 @@ const initialState: ContentsSearchParams = {
   keyword: '',
 };
 
-const Main: NextPage = function () {
+function Main() {
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
   const [searchParams, setSearchParams] =
@@ -170,9 +171,9 @@ const Main: NextPage = function () {
       </StyledMain>
     </>
   );
-};
+}
 
-export async function getServerSideProps() {
+export async function getServerSideProps(context: GetServerSidePropsContext) {
   try {
     const queryClient = new QueryClient();
     await queryClient.prefetchInfiniteQuery(
@@ -182,6 +183,7 @@ export async function getServerSideProps() {
     return {
       props: {
         dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
+        session: await getSession(context),
       },
     };
   } catch (e) {
@@ -189,4 +191,5 @@ export async function getServerSideProps() {
   }
 }
 
+Main.auth = false;
 export default Main;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,17 +1,11 @@
-import type { NextPage } from 'next';
+import type { GetServerSidePropsContext } from 'next';
 import { NextSeo } from 'next-seo';
-import { Box, Text, Button, styled } from '@nolmungshemung/ui-kits';
-import { signIn } from 'next-auth/react';
+import { Box, Text, Button } from '@nolmungshemung/ui-kits';
+import { getSession, signIn } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 
-const GuideText = styled(Text, {
-  color: '$gray',
-  paddingRight: '$sp-16',
-  fontWeight: '$regular',
-});
-
-const Login: NextPage = function () {
+function Login() {
   const router = useRouter();
   const { callbackUrl: urlParam } = router.query;
 
@@ -35,10 +29,10 @@ const Login: NextPage = function () {
           justifyContent: 'center',
         }}
       >
-        <Box css={{ marginBottom: '8rem' }}>
+        <Box css={{ marginBottom: '$sp-50' }}>
           <Text css={{ fontSize: '5rem' }}>WritingHub</Text>
         </Box>
-        <Box css={{ marginBottom: '$sp-32' }}>
+        <Box>
           <Button
             size="lg"
             color="white"
@@ -57,31 +51,22 @@ const Login: NextPage = function () {
             </Text>
           </Button>
         </Box>
-        <Box>
-          <GuideText size="xl">라이팅허브가 처음이신가요?</GuideText>
-          <GuideText
-            size="xl"
-            css={{
-              color: '#333333',
-              textDecoration: 'underline',
-              cursor: 'pointer',
-            }}
-          >
-            회원가입
-          </GuideText>
-          <GuideText
-            size="xl"
-            css={{
-              color: '#000000',
-              cursor: 'pointer',
-            }}
-          >
-            계정찾기
-          </GuideText>
-        </Box>
       </Box>
     </>
   );
-};
+}
 
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  try {
+    return {
+      props: {
+        session: await getSession(context),
+      },
+    };
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+Login.auth = false;
 export default Login;

--- a/pages/translating.tsx
+++ b/pages/translating.tsx
@@ -3,7 +3,7 @@ import { NextSeo } from 'next-seo';
 import { Box, Button, styled } from '@nolmungshemung/ui-kits';
 import { BasicInput } from '~/components/Input';
 import * as Table from '~/components/Table';
-import { GetServerSidePropsContext, NextPage, PreviewData } from 'next';
+import { GetServerSidePropsContext, PreviewData } from 'next';
 import { WritingContentsRequest } from '~/data/services/services.model';
 import TextEditor from '~/components/TextEditor/TextEditor';
 import {
@@ -17,12 +17,13 @@ import { useRouter } from 'next/router';
 import { ParsedUrlQuery } from 'querystring';
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
+import { getSession } from 'next-auth/react';
 
 const StyledTextEditor = styled(TextEditor, {
   width: '98%',
 });
 
-const Translating: NextPage = function () {
+function Translating() {
   const router = useRouter();
   const contentsId = Number(router.query.contentsId);
   const { data: targetOriginalContents, isLoading } =
@@ -273,7 +274,7 @@ const Translating: NextPage = function () {
       </Box>
     </>
   );
-};
+}
 
 export async function getServerSideProps(
   context: GetServerSidePropsContext<ParsedUrlQuery, PreviewData>,
@@ -288,6 +289,7 @@ export async function getServerSideProps(
     return {
       props: {
         dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
+        session: await getSession(context),
       },
     };
   } catch (e) {
@@ -295,4 +297,5 @@ export async function getServerSideProps(
   }
 }
 
+Translating.auth = true;
 export default Translating;

--- a/pages/writers.tsx
+++ b/pages/writers.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'react';
-import { NextPage } from 'next';
+import { GetServerSidePropsContext } from 'next';
 import { dehydrate, QueryClient } from 'react-query';
 import Router from 'next/router';
 import { useIntersectionObserver, useSearch } from '~/hooks';
@@ -17,6 +17,7 @@ import { SkeletonCard } from '~/components/Skeleton';
 import { DEFAULT_SEARCH_RANGE } from '~/shared/constants/pagination';
 import { NextSeo } from 'next-seo';
 import { MILLISEC_TO_SECOND } from '~/shared/constants/unit';
+import { getSession } from 'next-auth/react';
 
 const StyledMain = styled('div', {
   gridArea: 'main',
@@ -49,7 +50,7 @@ const initialState: ContentsSearchParams = {
   keyword: '',
 };
 
-const Main: NextPage = function () {
+function Writers() {
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
   const [searchParams, setSearchParams] =
@@ -177,9 +178,9 @@ const Main: NextPage = function () {
       </StyledMain>
     </>
   );
-};
+}
 
-export async function getServerSideProps() {
+export async function getServerSideProps(context: GetServerSidePropsContext) {
   try {
     const queryClient = new QueryClient();
     await queryClient.prefetchInfiniteQuery(
@@ -189,6 +190,7 @@ export async function getServerSideProps() {
     return {
       props: {
         dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
+        session: await getSession(context),
       },
     };
   } catch (e) {
@@ -196,4 +198,5 @@ export async function getServerSideProps() {
   }
 }
 
-export default Main;
+Writers.auth = false;
+export default Writers;

--- a/pages/writing.tsx
+++ b/pages/writing.tsx
@@ -3,10 +3,11 @@ import { NextSeo } from 'next-seo';
 import { Box, Button } from '@nolmungshemung/ui-kits';
 import { BasicInput } from '~/components/Input';
 import * as Table from '~/components/Table';
-import { NextPage } from 'next';
+import { GetServerSidePropsContext } from 'next';
 import { WritingContentsRequest } from '~/data/services/services.model';
 import TextEditor from '~/components/TextEditor/TextEditor';
 import { usePostContents } from '~/data/services/services.hooks';
+import { getSession } from 'next-auth/react';
 
 const initialWriting: WritingContentsRequest = {
   title: '',
@@ -19,7 +20,7 @@ const initialWriting: WritingContentsRequest = {
   originalId: 0,
 };
 
-const Writing: NextPage = function () {
+function Writing() {
   const [writingContents, setWritingContents] =
     useState<WritingContentsRequest>(initialWriting);
 
@@ -140,6 +141,19 @@ const Writing: NextPage = function () {
       </Box>
     </>
   );
-};
+}
 
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  try {
+    return {
+      props: {
+        session: await getSession(context),
+      },
+    };
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+Writing.auth = true;
 export default Writing;


### PR DESCRIPTION
### Short description

로그인 유무에 따른 페이지 권한관리 로직 추가

### Proposed changes

- Header에서 내피드, 필명등록 page redirect event 추가
- next-auth의 signIn, session callback 함수에 로직 추가
  - signIn: backend api와 연동 ( 유저정보 조회, 회원 가입 로직 추가 )
  - session: useSession시 필요한 userId(writerId)값 추가
### How to test (Optional)

_How to test this PR_

### Screenshots (Optional)

#### Before this PR

#### After this PR

### Reference (Optional)
close #59
