### PR TITLE
fix: 필명등록 시 userId 누락 이슈 수정

### DIFF
--- a/pages/registration/username.tsx
+++ b/pages/registration/username.tsx
@@ -3,8 +3,15 @@ import { NextSeo } from 'next-seo';
 import { Box, Text, Button } from '@nolmungshemung/ui-kits';
 import { BasicInput } from '~/components/Input';
 import { useNameRegistration } from '~/data/user/user.hooks';
+import { useSession } from 'next-auth/react';
+import { WritingHubSession } from '~/data/user/user.model';
 
 const PenName = function () {
+  const { data: session } = useSession();
+  const {
+    user: { id: userId },
+  } = session as WritingHubSession;
+
   const [userName, setUserName] = useState('');
   const [showError, setShowError] = useState(false);
 
@@ -30,7 +37,7 @@ const PenName = function () {
 
   const onPenNameRegist = () => {
     mutate({
-      userId: '',
+      userId,
       userName,
     });
   };
@@ -121,4 +128,5 @@ const PenName = function () {
   );
 };
 PenName.auth = true;
+
 export default PenName;


### PR DESCRIPTION
### Short description
필명등록 요청 시, userId 값이 안넘어가는 이슈 수정

### Proposed changes
PenName 페이지에서 useSession으로 다시 userId 가져와 api 호출.
(Auth 컴포넌트에서 useSession으로 체크하는데 PenName 페이지로 넘길 좋은 방법이 딱히 생각나지 않음.)

### How to test (Optional)

1. 로그인
2. 필명등록 페이지에서 필명등록
3. userId 잘 들어갔는지 확인 

### Reference (Optional)
_Closes #69